### PR TITLE
Add a 'install_requires' directive to setup.py to auto-install dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(name="yokadi",
       url="http://yokadi.github.com/",
       package_dir={"yokadi" : "src/yokadi"},
       packages=["yokadi", "yokadi.tests"],
+      install_requires=['sqlobject', 'dateutils'],
       scripts=scripts,
       data_files=data_files
       )


### PR DESCRIPTION
Hi,
As requested, here is the little patch to auto-install dependencies (currently sqlobject and dateutils, but you should keep it up to date in the future) when installing through pip. I tested it successfully with:

```
python setup.py sdist && pip install dist/yokadi-0.14.0.tar.gz
```

Thanks,
Stéphane
