### PR TITLE
Drop tests tables between two tests instead of just deleting data

### DIFF
--- a/src/yokadi/tests/testutils.py
+++ b/src/yokadi/tests/testutils.py
@@ -7,14 +7,17 @@ Utils for unit-test
 
 from core import db
 
+
 def clearDatabase():
     """
     Clear all tables of the database. Should be called in the setUp() method of
     the testcase. Useful to ensure unit-tests start from a blank state.
     """
+    print "Cleaning database"
     for table in db.TABLE_LIST:
-        table.clearTable()
-    # Recreate default parameters
+        table.dropTable()
+    # Recreate database and default parameters
+    db.connectDatabase("", memoryDatabase=True)
     db.setDefaultConfig()
 
 


### PR DESCRIPTION
Drop tests tables between two tests instead of just deleting data with some setups sqlite table sequence are not properly reseted
