### PR TITLE
Added Keywords field in Desktop file

### DIFF
--- a/icon/yokadi.desktop
+++ b/icon/yokadi.desktop
@@ -7,3 +7,4 @@ Terminal=true
 Icon=yokadi
 Type=Application
 Categories=Office;ProjectManagement;ConsoleOnly;
+Keywords=todo;projectmanagement;commandline;


### PR DESCRIPTION
As reported by Debian's Lintian tool. See: http://lintian.debian.org/tags/desktop-entry-lacks-keywords-entry.html
