### PR TITLE
Remove warning on aliases management

### DIFF
--- a/yokadi/tests/aliastestcase.py
+++ b/yokadi/tests/aliastestcase.py
@@ -22,7 +22,7 @@ class AliasTestCase(unittest.TestCase):
     def testAdd(self):
         self.cmd.do_a_add("l t_list")
         self.cmd.do_a_add("la t_list -a")
-        alias = self.session.query(Config).filter_by(name="ALIASES")[0]
+        alias = self.session.query(Config).filter_by(name=u"ALIASES")[0]
         self.assertEqual(eval(alias.value)["l"], "t_list")
         self.cmd.do_a_remove("l")
         self.cmd.do_a_remove("la")

--- a/yokadi/ycli/aliascmd.py
+++ b/yokadi/ycli/aliascmd.py
@@ -43,14 +43,13 @@ class AliasCmd(object):
         command = " ".join(tokens[1:])
         self.aliases.update({name: command})
         try:
-            aliases = session.query(db.Config).filter_by(name="ALIASES").one()
+            aliases = session.query(db.Config).filter_by(name=u"ALIASES").one()
         except NoResultFound:
             # Config entry does not exist. Create it.
-            aliases = db.Config(name="ALIASES", value="{}", system=True, desc="User command aliases")
-            session.add(aliases)
+            aliases = db.Config(name=u"ALIASES", value=u"{}", system=True, desc=u"User command aliases")
 
-        aliases.value = repr(self.aliases)
-        session.merge(aliases)
+        aliases.value = unicode(repr(self.aliases))
+        session.add(aliases)
         session.commit()
 
     def do_a_remove(self, line):
@@ -58,9 +57,9 @@ class AliasCmd(object):
         if line in self.aliases:
             session = db.DBHandler.getSession()
             del self.aliases[line]
-            aliases = session.query(db.Config).filter_by(name="ALIASES").one()
-            aliases.value = repr(self.aliases)
-            session.merge(aliases)
+            aliases = session.query(db.Config).filter_by(name=u"ALIASES").one()
+            aliases.value = unicode(repr(self.aliases))
+            session.add(aliases)
             session.commit()
         else:
             tui.error("No alias with that name. Use a_list to display all aliases")


### PR DESCRIPTION
- Convert string to unicode
- Use add instead of merge because we don't handle more than one session
