### PR TITLE
Fix suffix am|pm

### DIFF
--- a/yokadi/core/ydateutils.py
+++ b/yokadi/core/ydateutils.py
@@ -63,14 +63,12 @@ def guessTime(text):
     afternoon = False
     # We do not use the "%p" format to handle AM/PM because its behavior is
     # locale-dependent
-    if text[-1] == "m":
-        suffix = text[-2:]
-        if suffix == "am":
-            pass
-        elif suffix == "pm":
-            afternoon = True
-        else:
-            raise ValueError
+
+    suffix = text[-2:]
+    if suffix == "am":
+        text = text[:-2].strip()
+    elif suffix == "pm":
+        afternoon = True
         text = text[:-2].strip()
 
     out, fmt = testFormats(text, TIME_FORMATS)


### PR DESCRIPTION
indeed if user is using 17m we raise an exception instead of displaying an error message (format problem)