### PR TITLE
Install fixes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,11 +1,15 @@
+include bin/fromsrc.py
 include update/update*to*
 include update/*py
 include doc/*.md
 include man/*.1
+include icon/*
+include script/*
 include *py
 include README.md
 include LICENSE
 include MANIFEST.in
 include version
 include NEWS
-include yokadi
+include *requirements.txt
+include .travis.yml

--- a/doc/release.md
+++ b/doc/release.md
@@ -49,6 +49,7 @@ Write a blog entry in `_posts/`
 
 Update version in download page (download.markdown)
 
-## Tell the world
+## Upload on PyPI
 
-- pypi.python.org
+    cd download/
+    twine upload yokadi-<version>.*

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,12 @@ setup(name="yokadi",
         "yokadi.ycli",
         "yokadi.yical",
       ],
+      # distutils does not support install_requires, but pip needs it to be
+      # able to automatically install dependencies
+      install_requires=[
+        "sqlalchemy",
+        "python-dateutil",
+      ],
       scripts=scripts,
       data_files=data_files
       )


### PR DESCRIPTION
- Add `install_requires` keyword so that `pip install yokadi` install dependencies
- Add missing files in MANIFEST.in (those files were not necessary to install Yokadi, but would have make developing from the source in the archives more painful) 