### PR TITLE
Remove the need to import tui from core.db

### DIFF
--- a/yokadi/core/db.py
+++ b/yokadi/core/db.py
@@ -27,7 +27,6 @@ except ImportError:
     sys.exit(1)
 
 from yokadi.core.yokadiexception import YokadiException
-from yokadi.ycli import tui  # TODO: try to remove dependancy on tui
 from yokadi.core import utils
 
 # Yokadi database version needed for this code
@@ -38,6 +37,15 @@ DB_VERSION_KEY = "DB_VERSION"
 
 # Task frequency
 FREQUENCY = {0: "Yearly", 1: "Monthly", 2: "Weekly", 3: "Daily"}
+
+
+class DbUserError(Exception):
+    """
+    This exception is for errors which are not caused by a failure in our code
+    and which must be fixed by the user.
+    """
+    pass
+
 
 Base = declarative_base()
 
@@ -231,16 +239,14 @@ class Database(object):
         self.session = Session()
 
         if not os.path.exists(dbFileName) or memoryDatabase:
-            if createIfNeeded:
-                print("Creating %s" % dbFileName)
-                self.createTables()
-                # Set database version according to current yokadi release
-                if not updateMode: # Update script add it from dump
-                    self.session.add(Config(name=DB_VERSION_KEY, value=str(DB_VERSION), system=True, desc="Database schema release number"))
-                self.session.commit()
-            else:
-                print("Database file (%s) does not exist or is not readable. Exiting" % dbFileName)
-                sys.exit(1)
+            if not createIfNeeded:
+                raise DbUserError("Database file (%s) does not exist or is not readable." % dbFileName)
+            print("Creating %s" % dbFileName)
+            self.createTables()
+            # Set database version according to current yokadi release
+            if not updateMode: # Update script add it from dump
+                self.session.add(Config(name=DB_VERSION_KEY, value=str(DB_VERSION), system=True, desc="Database schema release number"))
+            self.session.commit()
 
         if not updateMode:
             self.checkVersion()
@@ -271,12 +277,10 @@ class Database(object):
         version = self.getVersion()
         if version != DB_VERSION:
             sharePath = os.path.abspath(utils.shareDirPath())
-            tui.error("Your database version is %d but Yokadi wants version %d." \
-                % (version, DB_VERSION))
-            print("Please, run the %s/update/update.py script to migrate your database prior to running Yokadi" % \
-                    sharePath)
-            print("See %s/doc/update.md for details" % sharePath)
-            sys.exit(1)
+            msg = "Your database version is %d but Yokadi wants version %d.\n" % (version, DB_VERSION)
+            msg += "Please run the %s/update/update.py script to migrate your database prior to running Yokadi.\n" % sharePath
+            msg += "See %s/doc/update.md for details." % sharePath
+            raise DbUserError(msg)
 
 
 def setDefaultConfig():

--- a/yokadi/ycli/main.py
+++ b/yokadi/ycli/main.py
@@ -223,7 +223,11 @@ def main():
             args.filename = os.path.normcase(os.path.expanduser("~/.yokadi.db"))
             print("Using default database (%s)" % args.filename)
 
-    db.connectDatabase(args.filename)
+    try:
+        db.connectDatabase(args.filename)
+    except db.DbUserError as exc:
+        print(exc)
+        sys.exit(1)
 
     if args.createOnly:
         return


### PR DESCRIPTION
Introduce a DbUserError exception, which is raised instead of using tui to show error messages and leaving with sys.exit().