### PR TITLE
New command to edit all tasks of a project: t_medit

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ include doc/*.md
 include man/*.1
 include icon/*
 include scripts/*
+include editors/vim/*/*.vim
 include *py
 include README.md
 include LICENSE

--- a/README.md
+++ b/README.md
@@ -253,6 +253,34 @@ explanatory:
     yokadi> a_list
     procrastinate => t_apply __ t_due +1d
 
+## Mass editing tasks
+
+`t_medit` lets you edit all tasks of a project at once by opening a text editor
+with all the tasks and let you editing them, applying the changes when you
+quit.  If you are familiar with `git`, this is similar to the way the `git
+rebase --interactive` command works.
+
+For example to edit all the tasks of the "birthday" project do the following:
+
+    yokadi> t_medit birthday
+
+Make adjustments to the task list (the syntax is documented as comments in the
+text opened in the editor), then save the file and quit to apply the changes.
+
+Yokadi provides Vim syntax highlighting files to make mass edit more
+convenient. You can find them in `editors/vim`. To install them, run the
+following:
+
+    cd place/to/editors/vim
+    mkdir -p ~/.vim/ftdetect
+    mkdir -p ~/.vim/syntax
+    cp ftdetect/medit.vim ~/.vim/ftdetect
+    cp syntax/medit.vim ~/.vim/syntax
+
+If you use another editor and can provide support for highlighting files, your
+contribution is very welcome! Get in touch so that we can add your work to the
+next version of Yokadi.
+
 # Integration
 
 ## Database location

--- a/editors/example.medit
+++ b/editors/example.medit
@@ -1,0 +1,16 @@
+1 N New task @kw1 @kw2=12
+2 S Started task
+3 D Done task
+4 n Lower case should work too
+5 s Lower case should work too
+6 d Lower case should work too
+- Just added this new task in this session
+- N Another freshly added task, this time with explicit "new" status
+- S Another freshly added task, this time with explicit "started" status
+- D Another freshly added task, this time with explicit "done" status
+- SSS This added task starts with an S, but the S is part of the first word of this task
+- NNN This added task starts with an N, but the N is part of the first word of this task
+- DDD This added task starts with an D, but the D is part of the first word of this task
+Not a valid line
+
+# Comments

--- a/editors/vim/ftdetect/yokadimedit.vim
+++ b/editors/vim/ftdetect/yokadimedit.vim
@@ -1,1 +1,1 @@
-au BufRead,BufNewFile *.medit set filetype=yokadimedit
+au BufRead,BufNewFile *.medit set filetype=yokadimedit textwidth=0

--- a/editors/vim/ftdetect/yokadimedit.vim
+++ b/editors/vim/ftdetect/yokadimedit.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.medit set filetype=yokadimedit

--- a/editors/vim/syntax/yokadimedit.vim
+++ b/editors/vim/syntax/yokadimedit.vim
@@ -11,7 +11,9 @@ syn case match
 
 syn match yokadimeditComment "^\s*#.*$" skipwhite
 syn match yokadimeditTaskId "\v^\s*(\d+|-)" nextgroup=yokadimeditStatus skipwhite
-syn match yokadimeditStatus "[NSD]" nextgroup=yokadimeditTitle contained
+syn match yokadimeditError "^\s*[^-0-9#].*" skipwhite
+
+syn match yokadimeditStatus "[NSDnsd] " nextgroup=yokadimeditTitle contained
 syn match yokadimeditTitle ".*" contains=yokadimeditKeyword contained
 syn match yokadimeditKeyword "@\w\+" contained
 syn match yokadimeditKeyword "@\w\+=\d\+" contained
@@ -20,5 +22,6 @@ hi def link yokadimeditComment Comment
 hi def link yokadimeditTaskId Constant
 hi def link yokadimeditStatus Statement
 hi def link yokadimeditKeyword Type
+hi def link yokadimeditError Error
 
 let b:current_syntax = "yokadimedit"

--- a/editors/vim/syntax/yokadimedit.vim
+++ b/editors/vim/syntax/yokadimedit.vim
@@ -1,0 +1,24 @@
+" Vim syntax file
+" Language: Yokadi t_medit
+" Maintainer: Aurélien Gâteau <mail@agateau.com>
+" Filenames: *.medit
+
+if exists("b:current_syntax")
+  finish
+endif
+
+syn case match
+
+syn match yokadimeditComment "^\s*#.*$" skipwhite
+syn match yokadimeditTaskId "\v^\s*(\d+|-)" nextgroup=yokadimeditStatus skipwhite
+syn match yokadimeditStatus "[NSD]" nextgroup=yokadimeditTitle contained
+syn match yokadimeditTitle ".*" contains=yokadimeditKeyword contained
+syn match yokadimeditKeyword "@\w\+" contained
+syn match yokadimeditKeyword "@\w\+=\d\+" contained
+
+hi def link yokadimeditComment Comment
+hi def link yokadimeditTaskId Constant
+hi def link yokadimeditStatus Statement
+hi def link yokadimeditKeyword Type
+
+let b:current_syntax = "yokadimedit"

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,10 @@ data_files.append(["share/man/man1", createFileList("man", "*.1")])
 # Update scripts
 data_files.append(["share/yokadi/update", createFileList("update", "*.py", "update*to*")])
 
+# Editor scripts
+data_files.append(["share/yokadi/editors/vim/ftdetect", ["editors/vim/ftdetect/yokadimedit.vim"]])
+data_files.append(["share/yokadi/editors/vim/syntax", ["editors/vim/syntax/yokadimedit.vim"]])
+
 # Icon
 for size in os.listdir("icon"):
     if not isdir(join("icon", size)):

--- a/yokadi/core/db.py
+++ b/yokadi/core/db.py
@@ -133,6 +133,22 @@ class Task(Base):
         else:
             return ""
 
+    def setStatus(self, status):
+        """
+        Defines the status of the task, taking care of updating the done date
+        and doing the right thing for recurrent tasks
+        """
+        if self.recurrence and status == "done":
+            self.dueDate = self.recurrence.getNext(self.dueDate)
+        else:
+            self.status = status
+            if status == "done":
+                self.doneDate = datetime.now().replace(second=0, microsecond=0)
+            else:
+                self.doneDate = None
+        session = getSession()
+        session.merge(self)
+
 
 class Recurrence(Base):
     """Task recurrence definition"""

--- a/yokadi/core/db.py
+++ b/yokadi/core/db.py
@@ -42,6 +42,9 @@ FREQUENCY = {0: "Yearly", 1: "Monthly", 2: "Weekly", 3: "Daily"}
 Base = declarative_base()
 
 
+NOTE_KEYWORD = "_note"
+
+
 class Project(Base):
     __tablename__ = "project"
     id = Column(Integer, primary_key=True)

--- a/yokadi/tests/massedittestcase.py
+++ b/yokadi/tests/massedittestcase.py
@@ -71,7 +71,6 @@ class MassEditTestCase(unittest.TestCase):
             12 D A done task
             - A newly added task
             - OneWordNewTask
-            - s is a cool letter
 
             # A comment
             """
@@ -82,7 +81,6 @@ class MassEditTestCase(unittest.TestCase):
             MEditEntry(12, "done", u"A done task", {}),
             MEditEntry(None, "new", u"A newly added task", {}),
             MEditEntry(None, "new", u"OneWordNewTask", {}),
-            MEditEntry(None, "new", u"s is a cool letter", {}),
         ]
         output = parseMEditText(text)
 

--- a/yokadi/tests/massedittestcase.py
+++ b/yokadi/tests/massedittestcase.py
@@ -39,7 +39,7 @@ class MassEditTestCase(unittest.TestCase):
 
         tasks = (t1, t2, t3, t4, t5)
 
-        oldList = massedit.createMEditEntriesForProject(prj)
+        oldList = massedit.createEntriesForProject(prj)
         newList = [
             MEditEntry(None, "new", u"Added", {}),
             MEditEntry(t1.id, "new", u"New text", {}),
@@ -48,7 +48,7 @@ class MassEditTestCase(unittest.TestCase):
             MEditEntry(t3.id, "done", u"Done", {}),
         ]
 
-        massedit.applyMEditChanges(prj, oldList, newList, interactive=False)
+        massedit.applyChanges(prj, oldList, newList, interactive=False)
         self.session.commit()
 
         newTask = self.session.query(db.Task).filter_by(title=u"Added").one()
@@ -91,7 +91,7 @@ class MassEditTestCase(unittest.TestCase):
         t1 = dbutils.addTask("p1", "Task", {})
         t2 = dbutils.addTask("p1", "Note", {NOTE_KEYWORD: None})
 
-        oldList = massedit.createMEditEntriesForProject(prj)
+        oldList = massedit.createEntriesForProject(prj)
         self.assertEqual(len(oldList), 1)
 
 # vi: ts=4 sw=4 et

--- a/yokadi/tests/massedittestcase.py
+++ b/yokadi/tests/massedittestcase.py
@@ -37,8 +37,6 @@ class MassEditTestCase(unittest.TestCase):
         self.session.commit()
         deletedId = t4.id
 
-        tasks = (t1, t2, t3, t4, t5)
-
         oldList = massedit.createEntriesForProject(prj)
         newList = [
             MEditEntry(None, "new", u"Added", {}),

--- a/yokadi/tests/massedittestcase.py
+++ b/yokadi/tests/massedittestcase.py
@@ -8,6 +8,7 @@ Mass edit test cases
 import unittest
 
 from yokadi.core import db
+from yokadi.core.db import NOTE_KEYWORD
 from yokadi.core import dbutils
 from yokadi.core.yokadiexception import YokadiException
 from yokadi.ycli import massedit
@@ -18,6 +19,8 @@ from yokadi.ycli.massedit import MEditEntry, parseMEditText
 class MassEditTestCase(unittest.TestCase):
     def setUp(self):
         db.connectDatabase("", memoryDatabase=True)
+        # FIXME: Do this in db
+        dbutils.getOrCreateKeyword(NOTE_KEYWORD, interactive=False)
         self.session = db.getSession()
         tui.clearInputAnswers()
 
@@ -82,5 +85,13 @@ class MassEditTestCase(unittest.TestCase):
         output = parseMEditText(text)
 
         self.assertEqual(output, expected)
+
+    def testOnlyListTasks(self):
+        prj = dbutils.getOrCreateProject("p1", interactive=False)
+        t1 = dbutils.addTask("p1", "Task", {})
+        t2 = dbutils.addTask("p1", "Note", {NOTE_KEYWORD: None})
+
+        oldList = massedit.createMEditEntriesForProject(prj)
+        self.assertEqual(len(oldList), 1)
 
 # vi: ts=4 sw=4 et

--- a/yokadi/tests/massedittestcase.py
+++ b/yokadi/tests/massedittestcase.py
@@ -117,4 +117,17 @@ class MassEditTestCase(unittest.TestCase):
         oldList = massedit.createEntriesForProject(prj)
         self.assertEqual(len(oldList), 1)
 
+    def testCreateMEditText(self):
+        e1 = MEditEntry(1, "N", "Hello", {})
+        e2 = MEditEntry(2, "S", "Started", {})
+        EXPECTED_TEXT = """1 N Hello
+2 S Started
+
+# doc1
+#
+# doc2
+"""
+
+        txt = massedit.createMEditText([e1, e2], docComment="doc1\n\ndoc2\n")
+        self.assertEqual(txt, EXPECTED_TEXT)
 # vi: ts=4 sw=4 et

--- a/yokadi/tests/massedittestcase.py
+++ b/yokadi/tests/massedittestcase.py
@@ -62,6 +62,20 @@ class MassEditTestCase(unittest.TestCase):
         self.assertEqual(t5.urgency, 2)
         self.assertEqual(t3.urgency, 1)
 
+    def testApplyMEditChangesUnknownIds(self):
+        prj = dbutils.getOrCreateProject("p1", interactive=False)
+        t1 = dbutils.addTask("p1", "Foo", {})
+        t2 = dbutils.addTask("p1", "Bar", {})
+
+        oldList = massedit.createEntriesForProject(prj)
+        newList = [
+            MEditEntry(t1.id, "new", t1.title, {}),
+            MEditEntry(t2.id + 1, "new", t2.title, {}),
+        ]
+
+        self.assertRaises(YokadiException, massedit.applyChanges, prj, oldList,
+                          newList, interactive=False)
+
     def testParseMEditText(self):
         text = """1 N Hello
             4 N Some keywords @foo @bar=1

--- a/yokadi/tests/massedittestcase.py
+++ b/yokadi/tests/massedittestcase.py
@@ -71,6 +71,7 @@ class MassEditTestCase(unittest.TestCase):
             12 D A done task
             - A newly added task
             - OneWordNewTask
+            - s is a cool letter
 
             # A comment
             """
@@ -81,6 +82,7 @@ class MassEditTestCase(unittest.TestCase):
             MEditEntry(12, "done", u"A done task", {}),
             MEditEntry(None, "new", u"A newly added task", {}),
             MEditEntry(None, "new", u"OneWordNewTask", {}),
+            MEditEntry(None, "new", u"s is a cool letter", {}),
         ]
         output = parseMEditText(text)
 

--- a/yokadi/tests/massedittestcase.py
+++ b/yokadi/tests/massedittestcase.py
@@ -13,7 +13,7 @@ from yokadi.core import dbutils
 from yokadi.core.yokadiexception import YokadiException
 from yokadi.ycli import massedit
 from yokadi.ycli import tui
-from yokadi.ycli.massedit import MEditEntry, parseMEditText
+from yokadi.ycli.massedit import MEditEntry, parseMEditText, ParseError
 
 
 class MassEditTestCase(unittest.TestCase):
@@ -85,6 +85,29 @@ class MassEditTestCase(unittest.TestCase):
         output = parseMEditText(text)
 
         self.assertEqual(output, expected)
+
+    def testParseMEditTextErrors(self):
+        testData = [
+            # Duplicate id
+            """
+            1 N X
+            1 N Y
+            """,
+            # Invalid id
+            """
+            A N X
+            """,
+            # Invalid status
+            """
+            1 z Y
+            """,
+            # Invalid line
+            """
+            bla
+            """
+        ]
+        for text in testData:
+            self.assertRaises(ParseError, parseMEditText, text)
 
     def testOnlyListTasks(self):
         prj = dbutils.getOrCreateProject("p1", interactive=False)

--- a/yokadi/tests/tests.py
+++ b/yokadi/tests/tests.py
@@ -39,6 +39,7 @@ from cryptotestcase import CryptoTestCase
 from tuitestcase import TuiTestCase
 from helptestcase import HelpTestCase
 from conftestcase import ConfTestCase
+from massedittestcase import MassEditTestCase
 
 
 def main():

--- a/yokadi/ycli/massedit.py
+++ b/yokadi/ycli/massedit.py
@@ -1,0 +1,138 @@
+# -*- coding: UTF-8 -*-
+"""
+Database utilities.
+
+@author: Aurélien Gâteau <mail@agateau.com>
+@license: GPL v3 or later
+"""
+from collections import namedtuple
+from datetime import datetime
+
+from sqlalchemy import desc
+
+from yokadi.core import db
+from yokadi.core.db import Task
+from yokadi.core.yokadiexception import YokadiException
+from yokadi.core import dbutils
+from yokadi.ycli import parseutils
+
+
+MEditEntry = namedtuple("MEditEntry", ["id", "status", "title", "keywords"])
+
+
+def createMEditText(entries):
+    def formatLine(entry):
+        status = entry.status[0].upper()
+        line = parseutils.createLine(None, entry.title, entry.keywords)
+        return "%d %s %s" % (entry.id, status, line)
+
+    lines = [formatLine(x) for x in entries]
+    return "\n".join(lines)
+
+
+def parseMEditText(text):
+    def createException(message):
+        return YokadiException("Error line %d (\"%s\"): %s" % (num + 1, line, message))
+
+    lst = []
+    for num, line in enumerate(text.split("\n")):
+        line = line.strip()
+        if not line or line[0] == "#":
+            continue
+        tokens = line.split(" ", 2)
+        nbTokens = len(tokens)
+        if nbTokens < 3:
+            if nbTokens == 2 and tokens[0] == "-":
+                # Special case: adding a one-word new task
+                tokens.append("")
+            else:
+                raise createException("Invalid line")
+
+        if tokens[0] == "-":
+            id = None
+        else:
+            try:
+                id = int(tokens[0])
+            except ValueError:
+                raise createException("Invalid id value")
+
+        statusChar = tokens[1].lower()
+        line = tokens[2]
+        if statusChar == "n":
+            status = "new"
+        elif statusChar == "s":
+            status = "started"
+        elif statusChar == "d":
+            status = "done"
+        elif id == None:
+            # Special case: if this is a new task, then statusChar is actually a
+            # one-letter word starting the task title
+            status = "new"
+            line = tokens[1] + ((" " + line) if line else "")
+        else:
+            raise createException("Invalid status")
+
+        _, title, keywords = parseutils.parseLine("dummy " + line)
+
+        lst.append(MEditEntry(id, status, title, keywords))
+    return lst
+
+
+def createMEditEntriesForProject(project):
+    session = db.getSession()
+    lst = session.query(Task).filter(Task.projectId == project.id,
+                                     Task.status != 'done').order_by(desc(Task.urgency))
+    return [createMEditEntryForTask(x) for x in lst]
+
+
+def createMEditEntryForTask(task):
+    return MEditEntry(task.id, task.status, task.title, task.getKeywordDict())
+
+
+def applyMEditChanges(project, oldList, newList, interactive=True):
+    """
+    Modify a project so that its task list is newList
+
+    @param project: the project name
+    @param oldList: a list of Task instances
+    @param newList: a list of MEditEntry
+    @param interactive: whether to confirm creation of new keywords
+    """
+    session = db.getSession()
+
+    # Sanity check: all ids in newList should be in oldList
+    oldIds = set([x.id for x in oldList])
+    newIds = set([x.id for x in newList if x.id is not None])
+    unknownIds = newIds.difference(oldIds)
+    if unknownIds:
+        idString = ", ".join([str(x) for x in unknownIds])
+        raise YokadiException("Unknown id(s): %s" % idString)
+
+    # Check keywords
+    for entry in newList:
+        for name in entry.keywords:
+            dbutils.getOrCreateKeyword(name, interactive=interactive)
+
+    # Remove tasks whose lines have been deleted
+    for id in oldIds.difference(newIds):
+        task = dbutils.getTaskFromId(id)
+        session.delete(task)
+
+    # Update existing tasks, add new ones
+    nbTasks = len(newList)
+    for pos, newEntry in enumerate(newList):
+        if newEntry.id:
+            task = dbutils.getTaskFromId(newEntry.id)
+        else:
+            task = Task(creationDate=datetime.now().replace(second=0, microsecond=0), project=project)
+        task.title = newEntry.title
+        task.setKeywordDict(newEntry.keywords)
+        task.setStatus(newEntry.status)
+        task.urgency = nbTasks - pos
+        if newEntry.id:
+            session.merge(task)
+        else:
+            session.add(task)
+
+
+# vi: ts=4 sw=4 et

--- a/yokadi/ycli/massedit.py
+++ b/yokadi/ycli/massedit.py
@@ -24,29 +24,29 @@ MEditEntry = namedtuple("MEditEntry", ["id", "status", "title", "keywords"])
 DOC_COMMENT = """
 Line format: <id> <status> <task title>
 
-You can change the status string to one of:
+To change the title of a task, just change the text after the status character.
+You can add or remove keywords like you do when using t_add.
+
+To change the status of a task, change the status character to one of:
  N new
  S started
  D done
 
-Edit the text after the status to change the task title. You can add or
-remove keywords just like you do when using t_add.
+To add a new task, add a new line using '-' for the task id. If you do not
+specify a status, the task will be marked as new. Examples:
 
-Do NOT edit the task id, this will confuse Yokadi.
+- Do more work
+- S A task that has already been started
 
-Add new lines to add new tasks. Use '-' for the task id. If you don't specify
-the status, the task will be marked as new. Examples:
+To adust task urgencies, re-order the lines.
 
-    - Do more work
-    - S A task that has already been started
+To remove a task, delete its line or comment it out with '#'.
 
-Re-order lines to define priorities.
+To cancel changes, quit without saving.
 
-Remove a line to permanently delete a task.
+Empty lines and lines starting with a '#' are ignored.
 
-Empty lines or lines starting with a '#' are ignored.
-
-Quit without saving to cancel all changes.
+Warning: Do NOT edit the task id, this will confuse Yokadi.
 """
 
 

--- a/yokadi/ycli/massedit.py
+++ b/yokadi/ycli/massedit.py
@@ -50,6 +50,14 @@ Quit without saving to cancel all changes.
 """
 
 
+class ParseError(YokadiException):
+    def __init__(self, lineNumber, line, message):
+        fullMessage = "Error line %d (\"%s\"): %s" % (lineNumber + 1, line, message)
+        YokadiException.__init__(self, fullMessage)
+        self.lineNumber = lineNumber
+        self.message = message
+
+
 def createMEditText(entries):
     def formatLine(entry):
         status = entry.status[0].upper()
@@ -63,7 +71,7 @@ def createMEditText(entries):
 
 def parseMEditText(text):
     def createException(message):
-        return YokadiException("Error line %d (\"%s\"): %s" % (num + 1, line, message))
+        return ParseError(num + 1, line, message)
 
     lst = []
     for num, line in enumerate(text.split("\n")):

--- a/yokadi/ycli/massedit.py
+++ b/yokadi/ycli/massedit.py
@@ -79,21 +79,21 @@ def parseMEditText(text):
     return lst
 
 
-def createMEditEntriesForProject(project):
+def createEntriesForProject(project):
     session = db.getSession()
     lst = session.query(Task).filter(Task.projectId == project.id,
                                      Task.status != 'done')
 
     lst = KeywordFilter(NOTE_KEYWORD, negative=True).apply(lst)
     lst = lst.order_by(desc(Task.urgency))
-    return [createMEditEntryForTask(x) for x in lst]
+    return [createEntryForTask(x) for x in lst]
 
 
-def createMEditEntryForTask(task):
+def createEntryForTask(task):
     return MEditEntry(task.id, task.status, task.title, task.getKeywordDict())
 
 
-def applyMEditChanges(project, oldList, newList, interactive=True):
+def applyChanges(project, oldList, newList, interactive=True):
     """
     Modify a project so that its task list is newList
 

--- a/yokadi/ycli/massedit.py
+++ b/yokadi/ycli/massedit.py
@@ -74,6 +74,7 @@ def parseMEditText(text):
         return ParseError(num + 1, line, message)
 
     lst = []
+    ids = set()
     for num, line in enumerate(text.split("\n")):
         line = line.strip()
         if not line or line[0] == "#":
@@ -94,6 +95,9 @@ def parseMEditText(text):
                 id = int(tokens[0])
             except ValueError:
                 raise createException("Invalid id value")
+            if id in ids:
+                raise createException("Duplicate id value")
+            ids.add(id)
 
         statusChar = tokens[1].lower()
         line = tokens[2]

--- a/yokadi/ycli/massedit.py
+++ b/yokadi/ycli/massedit.py
@@ -59,15 +59,23 @@ class ParseError(YokadiException):
         self.message = message
 
 
-def createMEditText(entries):
+def createMEditText(entries, docComment=DOC_COMMENT):
     def formatLine(entry):
         status = entry.status[0].upper()
         line = parseutils.createLine(None, entry.title, entry.keywords)
         return "%d %s %s" % (entry.id, status, line)
 
+    def prefixComment(comment):
+        for line in comment.strip().splitlines():
+            if line:
+                yield "# " + line
+            else:
+                yield "#"
+
     lines = [formatLine(x) for x in entries]
-    lines.append("\n# ".join(DOC_COMMENT.splitlines()))
-    return "\n".join(lines)
+    lines.append('')
+    lines.extend(prefixComment(docComment))
+    return "\n".join(lines) + "\n"
 
 
 def parseMEditLine(line):

--- a/yokadi/ycli/massedit.py
+++ b/yokadi/ycli/massedit.py
@@ -21,6 +21,35 @@ from yokadi.ycli import parseutils
 MEditEntry = namedtuple("MEditEntry", ["id", "status", "title", "keywords"])
 
 
+DOC_COMMENT = """
+Line format: <id> <status> <task title>
+
+You can change the status string to one of:
+ N new
+ S started
+ D done
+
+Edit the text after the status to change the task title. You can add or
+remove keywords just like you do when using t_add.
+
+Do NOT edit the task id, this will confuse Yokadi.
+
+Add new lines to add new tasks. Use '-' for the task id. If you don't specify
+the status, the task will be marked as new. Examples:
+
+    - Do more work
+    - S A task that has already been started
+
+Re-order lines to define priorities.
+
+Remove a line to permanently delete a task.
+
+Empty lines or lines starting with a '#' are ignored.
+
+Quit without saving to cancel all changes.
+"""
+
+
 def createMEditText(entries):
     def formatLine(entry):
         status = entry.status[0].upper()
@@ -28,6 +57,7 @@ def createMEditText(entries):
         return "%d %s %s" % (entry.id, status, line)
 
     lines = [formatLine(x) for x in entries]
+    lines.append("\n# ".join(DOC_COMMENT.splitlines()))
     return "\n".join(lines)
 
 

--- a/yokadi/ycli/massedit.py
+++ b/yokadi/ycli/massedit.py
@@ -35,10 +35,11 @@ To change the status of a task, change the status character to one of:
 To add a new task, add a new line using '-' for the task id. If you do not
 specify a status, the task will be marked as new. Examples:
 
-- Do more work
-- S A task that has already been started
+- This is a new task
+- N This is another new task
+- S This task has already been started
 
-To adust task urgencies, re-order the lines.
+To adjust task urgencies, re-order the lines.
 
 To remove a task, delete its line or comment it out with '#'.
 

--- a/yokadi/ycli/massedit.py
+++ b/yokadi/ycli/massedit.py
@@ -11,9 +11,10 @@ from datetime import datetime
 from sqlalchemy import desc
 
 from yokadi.core import db
-from yokadi.core.db import Task
+from yokadi.core.db import Task, NOTE_KEYWORD
 from yokadi.core.yokadiexception import YokadiException
 from yokadi.core import dbutils
+from yokadi.core.dbutils import KeywordFilter
 from yokadi.ycli import parseutils
 
 
@@ -81,7 +82,10 @@ def parseMEditText(text):
 def createMEditEntriesForProject(project):
     session = db.getSession()
     lst = session.query(Task).filter(Task.projectId == project.id,
-                                     Task.status != 'done').order_by(desc(Task.urgency))
+                                     Task.status != 'done')
+
+    lst = KeywordFilter(NOTE_KEYWORD, negative=True).apply(lst)
+    lst = lst.order_by(desc(Task.urgency))
     return [createMEditEntryForTask(x) for x in lst]
 
 

--- a/yokadi/ycli/taskcmd.py
+++ b/yokadi/ycli/taskcmd.py
@@ -706,7 +706,7 @@ class TaskCmd(object):
         except (MultipleResultsFound, NoResultFound):
             raise BadUsageException("You must provide a valid project name")
 
-        oldList = massedit.createMEditEntriesForProject(project)
+        oldList = massedit.createEntriesForProject(project)
         oldText = massedit.createMEditText(oldList)
         newText = oldText
         while True:
@@ -726,7 +726,7 @@ class TaskCmd(object):
                     return
 
             try:
-                massedit.applyMEditChanges(project, oldList, newList)
+                massedit.applyChanges(project, oldList, newList)
                 self.session.commit()
                 break
             except YokadiException as exc:

--- a/yokadi/ycli/taskcmd.py
+++ b/yokadi/ycli/taskcmd.py
@@ -703,7 +703,10 @@ class TaskCmd(object):
         - adjust urgency
         - delete tasks
         """
-        projectName = self._realProjectName(line)
+        if not line:
+            raise BadUsageException("Missing parameters")
+        projectName = parseutils.parseProjectName(line)
+        projectName = self._realProjectName(projectName)
         project = dbutils.getOrCreateProject(projectName)
         if not project:
             return

--- a/yokadi/ycli/taskcmd.py
+++ b/yokadi/ycli/taskcmd.py
@@ -710,7 +710,7 @@ class TaskCmd(object):
         oldText = massedit.createMEditText(oldList)
         newText = oldText
         while True:
-            newText = tui.editText(newText)
+            newText = tui.editText(newText, suffix=".medit")
             if newText == oldText:
                 print("No changes")
                 return

--- a/yokadi/ycli/taskcmd.py
+++ b/yokadi/ycli/taskcmd.py
@@ -267,19 +267,13 @@ class TaskCmd(object):
 
     def _t_set_status(self, line, status):
         task = self.getTaskFromId(line)
+        task.setStatus(status)
+        self.session.commit()
         if task.recurrence and status == "done":
-            task.dueDate = task.recurrence.getNext(task.dueDate)
             print("Task '%s' next occurrence is scheduled at %s" % (task.title, task.dueDate))
             print("To *really* mark this task done and forget it, remove its recurrence first with t_recurs %s none" % task.id)
         else:
-            task.status = status
-            if status == "done":
-                task.doneDate = datetime.now().replace(second=0, microsecond=0)
-            else:
-                task.doneDate = None
             print("Task '%s' marked as %s" % (task.title, status))
-        self.session.merge(task)
-        self.session.commit()
 
     def do_t_apply(self, line):
         """Apply a command to several tasks.

--- a/yokadi/ycli/taskcmd.py
+++ b/yokadi/ycli/taskcmd.py
@@ -694,13 +694,15 @@ class TaskCmd(object):
 
     def do_t_medit(self, line):
         """Mass edit tasks of a project.
-        It works by starting an editor with the task list, you can then:
+        t_medit <project_name>
+
+        Starts a text editor with the task list, you can then:
+        - edit tasks text and keywords
         - mark tasks as done or started
         - add new tasks
-        - change tasks text and flags
-        - change the order of the lines, urgency is updated to match this order
-        - remove tasks
-        t_medit <project_name>"""
+        - adjust urgency
+        - delete tasks
+        """
         try:
             project = self.session.query(Project).filter_by(name=line).one()
         except (MultipleResultsFound, NoResultFound):

--- a/yokadi/ycli/taskcmd.py
+++ b/yokadi/ycli/taskcmd.py
@@ -704,10 +704,9 @@ class TaskCmd(object):
         - delete tasks
         """
         projectName = self._realProjectName(line)
-        try:
-            project = self.session.query(Project).filter_by(name=projectName).one()
-        except (MultipleResultsFound, NoResultFound):
-            raise BadUsageException("You must provide a valid project name")
+        project = dbutils.getOrCreateProject(projectName)
+        if not project:
+            return
 
         oldList = massedit.createEntriesForProject(project)
         oldText = massedit.createMEditText(oldList)

--- a/yokadi/ycli/taskcmd.py
+++ b/yokadi/ycli/taskcmd.py
@@ -703,8 +703,9 @@ class TaskCmd(object):
         - adjust urgency
         - delete tasks
         """
+        projectName = self._realProjectName(line)
         try:
-            project = self.session.query(Project).filter_by(name=line).one()
+            project = self.session.query(Project).filter_by(name=projectName).one()
         except (MultipleResultsFound, NoResultFound):
             raise BadUsageException("You must provide a valid project name")
 

--- a/yokadi/ycli/taskcmd.py
+++ b/yokadi/ycli/taskcmd.py
@@ -717,10 +717,13 @@ class TaskCmd(object):
 
             try:
                 newList = massedit.parseMEditText(newText)
-            except YokadiException as exc:
+            except massedit.ParseError as exc:
                 print(exc)
                 print()
                 if tui.confirm("Modify text and try again"):
+                    lst = newText.splitlines()
+                    lst.insert(exc.lineNumber, "# ^ " + exc.message)
+                    newText = "\n".join(lst)
                     continue
                 else:
                     return

--- a/yokadi/ycli/taskcmd.py
+++ b/yokadi/ycli/taskcmd.py
@@ -14,7 +14,7 @@ from dateutil import rrule
 from sqlalchemy import or_, and_, desc
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 
-from yokadi.core.db import Keyword, Project, Task, TaskKeyword, Recurrence
+from yokadi.core.db import Keyword, Project, Task, TaskKeyword, Recurrence, NOTE_KEYWORD
 from yokadi.core import bugutils
 from yokadi.core import dbutils
 from yokadi.core import db
@@ -40,8 +40,6 @@ gRendererClassDict = dict(
     html=HtmlListRenderer,
     plain=PlainListRenderer,
     )
-
-NOTE_KEYWORD = "_note"
 
 
 class TaskCmd(object):

--- a/yokadi/ycli/tui.py
+++ b/yokadi/ycli/tui.py
@@ -48,11 +48,12 @@ stdout = IOStream(sys.stdout)
 stderr = IOStream(sys.stderr)
 
 
-def editText(text, onChanged=None, lockManager=None, prefix="yokadi-"):
+def editText(text, onChanged=None, lockManager=None, prefix="yokadi-", suffix=".md"):
     """Edit text with external editor
     @param onChanged: function parameter that is call whenever edited data change. Data is given as a string
     @param lockManager: function parameter that is called to 'acquire', 'update' or 'release' an editing lock
     @param prefix: temporary file prefix.
+    @param suffix: temporary file suffix.
     @return: newText"""
     encoding = locale.getpreferredencoding()
     def readFile(name):
@@ -70,7 +71,7 @@ def editText(text, onChanged=None, lockManager=None, prefix="yokadi-"):
     prefix = MULTIPLE_DASH.sub("-", prefix)
     prefix = unicodedata.normalize('NFKD', prefix)
 
-    (fd, name) = tempfile.mkstemp(suffix=".md", prefix=prefix)
+    (fd, name) = tempfile.mkstemp(suffix=suffix, prefix=prefix)
     if text is None:
         text = ""
     try:


### PR DESCRIPTION
This PR adds a new command: `t_medit`, which brings a new way to interact with your tasks: run `t_medit <project>` to edit, add, remove and reorder tasks of a project. It works like `git rebase --interactive`: Changes are applied when the text is edited.

Here is a screenshot:

![medit](https://cloud.githubusercontent.com/assets/3575/11669052/dcc7ca5c-9dfa-11e5-9fba-f50a1281be67.png)

This is useful when you want to quickly create tasks, since it's as fast as adding lines in a text file, but you can manage almost all aspects of a task (except description and recurrence) with it.

When|If this is merged we can deprecate `t_reorder`, since `t_medit` also supports reordering tasks.