### PR TITLE
Fix invalid TaskKeyword rows

### DIFF
--- a/update/update8to9
+++ b/update/update8to9
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+"""
+Update from version 8 to version 9 of Yokadi DB
+
+- Delete invalid TaskKeyword rows
+
+@author: Aurélien Gâteau <mail@agateau.com>
+@license: GPL v3 or newer
+"""
+import sys
+
+from sqlalchemy import create_engine
+
+
+# TODO: Current db version is 8, but this file has been created so that when we
+# create version 9, we can do the work which is currently done in
+# db.deleteInvalidTaskKeywordRows() and remove db.deleteInvalidTaskKeywordRows()
+#
+# The cleanup is done at startup for db version 8 because it is a fast,
+# data-only cleanup so it is not worth requiring users to update their database
+# schema.
+
+
+def deleteInvalidTaskKeywordRows(conn):
+    conn.execute('delete from task_keyword where task_id is null or keyword_id is null')
+
+
+def main():
+    uri = 'sqlite:///' + sys.argv[1]
+    engine = create_engine(uri)
+    with engine.begin() as conn:
+        deleteInvalidTaskKeywordRows(conn)
+
+
+if __name__ == "__main__":
+    main()
+# vi: ts=4 sw=4 et

--- a/yokadi/core/db.py
+++ b/yokadi/core/db.py
@@ -58,14 +58,10 @@ class Keyword(Base):
     id = Column(Integer, primary_key=True)
     name = Column(Unicode, unique=True)
     tasks = association_proxy("taskKeywords", "task")
-    projects = association_proxy("projectKeywords", "project")
     taskKeywords = relationship("TaskKeyword", cascade="all", backref="keyword")
 
     def __repr__(self):
         return self.name
-
-    def getTasks(self):
-        return [taskKeyword.task for taskKeyword in self.taskKeywords]
 
 
 class TaskKeyword(Base):

--- a/yokadi/core/db.py
+++ b/yokadi/core/db.py
@@ -15,7 +15,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import sessionmaker, relationship
 from sqlalchemy.orm.exc import NoResultFound
-from sqlalchemy import Column, Integer, Boolean, Unicode, DateTime, Enum, ForeignKey
+from sqlalchemy import Column, Integer, Boolean, Unicode, DateTime, Enum, ForeignKey, or_
 
 
 try:
@@ -293,4 +293,12 @@ def setDefaultConfig():
         if session.query(Config).filter_by(name=name).count() == 0:
             session.add(Config(name=name, value=value[0], system=value[1], desc=value[2]))
 
+
+def deleteInvalidTaskKeywordRows():
+    # TODO: Remove this function when we migrate to database version 9. See
+    # update8to9.
+    session = getSession()
+    filters = or_(TaskKeyword.taskId == None, TaskKeyword.keywordId == None)
+    session.query(TaskKeyword).filter(filters).delete(synchronize_session=False)
+    session.commit()
 # vi: ts=4 sw=4 et

--- a/yokadi/core/db.py
+++ b/yokadi/core/db.py
@@ -59,6 +59,7 @@ class Keyword(Base):
     name = Column(Unicode, unique=True)
     tasks = association_proxy("taskKeywords", "task")
     projects = association_proxy("projectKeywords", "project")
+    taskKeywords = relationship("TaskKeyword", cascade="all", backref="keyword")
 
     def __repr__(self):
         return self.name
@@ -73,7 +74,6 @@ class TaskKeyword(Base):
     taskId = Column("task_id", Integer, ForeignKey("task.id"))
     keywordId = Column("keyword_id", Integer, ForeignKey("keyword.id"))
     value = Column(Integer, default=None)
-    keyword = relationship("Keyword", backref="taskKeywords")
 
 
 class Task(Base):

--- a/yokadi/tests/keywordtestcase.py
+++ b/yokadi/tests/keywordtestcase.py
@@ -59,4 +59,14 @@ class KeywordTestCase(unittest.TestCase):
         self.assertTrue("k2" in kwDict)
 
         dbutils.getKeywordFromName("k1")
+
+    def testKRemove(self):
+        t1 = dbutils.addTask("x", "t1", dict(k1=12, k2=None), interactive=False)
+        tui.addInputAnswers("y")
+        self.cmd.do_k_remove("k1")
+        kwDict = t1.getKeywordDict()
+        self.assertFalse("k1" in kwDict)
+        self.assertTrue("k2" in kwDict)
+        taskKeyword = self.session.query(db.TaskKeyword).filter_by(taskId=t1.id).one()
+        self.assertEqual(taskKeyword.keyword.name, "k2")
 # vi: ts=4 sw=4 et

--- a/yokadi/ycli/main.py
+++ b/yokadi/ycli/main.py
@@ -228,6 +228,7 @@ def main():
     if args.createOnly:
         return
     db.setDefaultConfig()  # Set default config parameters
+    db.deleteInvalidTaskKeywordRows()
 
     cmd = YokadiCmd()
 


### PR DESCRIPTION
The SQLAlchemy port introduced a regression: removing a keyword from a task or deleting a keyword no longer deletes the matching TaskKeyword rows. This PR fixes the way relationships are defined so that TaskKeyword rows are correctly removed. It also adds a cleanup function called at startup to delete existing invalid TaskKeyword rows. Finally, it adds a matching cleanup function in update8to9 so that the startup cleanup function can be removed when we migrate to database version 9.