### PR TITLE
Fix suffix am|pm

### DIFF
--- a/yokadi/core/ydateutils.py
+++ b/yokadi/core/ydateutils.py
@@ -63,14 +63,11 @@ def guessTime(text):
     afternoon = False
     # We do not use the "%p" format to handle AM/PM because its behavior is
     # locale-dependent
-    if text[-1] == "m":
-        suffix = text[-2:]
-        if suffix == "am":
-            pass
-        elif suffix == "pm":
-            afternoon = True
-        else:
-            raise ValueError
+    suffix = text[-2:]
+    if suffix == "am":
+        text = text[:-2].strip()
+    elif suffix == "pm":
+        afternoon = True
         text = text[:-2].strip()
 
     out, fmt = testFormats(text, TIME_FORMATS)

--- a/yokadi/tests/ydateutilstestcase.py
+++ b/yokadi/tests/ydateutilstestcase.py
@@ -7,7 +7,7 @@ Date utilities test cases
 
 import unittest
 import operator
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, time
 
 from yokadi.core import ydateutils
 from yokadi.core.yokadiexception import YokadiException
@@ -122,5 +122,15 @@ class YDateUtilsTestCase(unittest.TestCase):
             output = ydateutils.parseDateLimit(text, today=today)
             self.assertEqual(expectedOp, output[0])
             self.assertEqual(expectedDate, output[1])
+
+    def testGuessTime(self):
+        for invalidTime in ("+5M", "+1m", "+2H", "+3h", "+9D", "+14d", "+432W", "+0w",
+                     "01/01/2009", "10/10/2008 12", "7/7/2007 10:15", "1/2/2003 1:2:3"):
+            self.assertIsNone(ydateutils.guessTime(invalidTime))
+
+
+        for text, expected_result in (('12:05:20', time(hour=12, minute=5, second=20)), ('10:00am', time(hour=10)), ('7:30pm', time(hour=19, minute=30))):
+            output = ydateutils.guessTime(text)
+            self.assertEqual(expected_result, output)
 
 # vi: ts=4 sw=4 et


### PR DESCRIPTION
indeed if user is using 17m we raise an exception instead of displaying an error message (format problem)

I create a new PR the previous one is totally out of date was easiest to create a new one and add test than rebasing/merging the previous one.

If I well understood I need to do my PR against v1.0-dev is not the good one let me know I will do it against the good one.
