### PR TITLE
Use setup from setuptools instead of distutils.core

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@
 @license:GPL v3 or newer
 """
 
-from distutils.core import setup
+from setuptools import setup
 import sys
 import os
 from fnmatch import fnmatch


### PR DESCRIPTION
It works the same, but the setuptools version supports
--single-version-externally-managed which is needed to
get along with the OpenBSD ports infrastructure.